### PR TITLE
add example. uses edit distances and a result table

### DIFF
--- a/examples/edit_distances.p6
+++ b/examples/edit_distances.p6
@@ -1,0 +1,30 @@
+use v6;
+use Text::Levenshtein::Damerau; 
+use Text::Table::Simple;
+use Benchmark;
+
+# benchmark.p6 <number of runs>
+sub MAIN(Int $runs = 10) {
+    for 1,5,20 -> Int $multiplier {
+        my Str $str1 = "four"  x $multiplier;
+        my Str $str2 = "fuoru" x $multiplier;
+        
+        say "Testing lengths:\n\$str1 = {$str1.chars}\t\$str1 = {$str2.chars}";
+
+        my %results = timethese($runs, {
+            'Text::Levenshtein::Damerau::{"&dld"}' 
+                => sub { Text::Levenshtein::Damerau::{"&dld($str1,$str2)"} 
+            },
+            'Text::Levenshtein::Damerau::{"&ld"}' 
+                => sub { Text::Levenshtein::Damerau::{"&ld($str1,$str2)"}  
+            },
+        });
+
+        my @headers = ['func','start','end','diff','avg'];
+        my @rows    = %results.map({ [.key,.value.list] });
+
+        my @table = lol2table(@headers,@rows);
+
+        $_.say for @table;
+    }
+}


### PR DESCRIPTION
perl6 examples/edit_distances.p6
    <pre><code>
    Testing lengths:
    $str1 = 4       $str1 = 5
    O-------------------------------------------O------------O------------O------O-----O
    | func                                      | start      | end        | diff | avg |
    |----------------------------------------------------------------------------------|
    | Text::Levenshtein::Damerau::{"&dld"}      | 1415165721 | 1415165722 | 1    | 0.1 |
    | Text::Levenshtein::Damerau::{"&ld"}       | 1415165722 | 1415165722 | 0    | 0   |
    O-------------------------------------------O------------O------------O------O-----O
    Testing lengths:
    $str1 = 20      $str1 = 25
    O-------------------------------------------O------------O------------O------O-----O
    | func                                      | start      | end        | diff | avg |
    |----------------------------------------------------------------------------------|
    | Text::Levenshtein::Damerau::{"&dld"}      | 1415165722 | 1415165724 | 2    | 0.2 |
    | Text::Levenshtein::Damerau::{"&ld"}       | 1415165724 | 1415165726 | 2    | 0.2 |
    O-------------------------------------------O------------O------------O------O-----O
    Testing lengths:
    $str1 = 80      $str1 = 100
    O-------------------------------------------O------------O------------O------O-----O
    | func                                      | start      | end        | diff | avg |
    |----------------------------------------------------------------------------------|
    | Text::Levenshtein::Damerau::{"&dld"}      | 1415165727 | 1415165758 | 31   | 3.1 |
    | Text::Levenshtein::Damerau::{"&ld"}       | 1415165758 | 1415165792 | 34   | 3.4 |
    O-------------------------------------------O------------O------------O------O-----O
</code></pre>
